### PR TITLE
Require omniauth

### DIFF
--- a/lib/omniauth/strategies/chef.rb
+++ b/lib/omniauth/strategies/chef.rb
@@ -1,4 +1,5 @@
 require 'chef'
+require 'omniauth'
 
 module OmniAuth
   module Strategies


### PR DESCRIPTION
Fixes an uninitialized-constant error (OmniAuth::Strategy) during Rails initialization.
