### PR TITLE
Correct call ServerAPI.new, allow configurable ssl_verify_mode

### DIFF
--- a/lib/omniauth/strategies/chef.rb
+++ b/lib/omniauth/strategies/chef.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 require 'chef'
+require 'chef/config'
 require 'omniauth'
 
 module OmniAuth
@@ -23,6 +24,7 @@ module OmniAuth
       include OmniAuth::Strategy
 
       option :endpoint,     'https://api.opscode.piab'
+      option :ssl_verify_mode, :verify_peer
       option :fields,       [:name, :password]
       option :headers,      { }
       option :organization, nil
@@ -81,7 +83,8 @@ module OmniAuth
       end
 
       def chef
-        ::Chef::ServerAPI.new endpoint, options.superuser, nil, parameters
+        ::Chef::Config.ssl_verify_mode options.ssl_verify_mode.to_sym
+        ::Chef::ServerAPI.new endpoint, parameters
       end
 
       def endpoint
@@ -101,7 +104,10 @@ module OmniAuth
       end
 
       def parameters
-        { headers: headers, raw_key: key }
+        { headers: headers,
+          client_name: options.superuser,
+          client_key: nil,
+          raw_key: key }
       end
 
       def password


### PR DESCRIPTION
The upgrade to Chef 12 in commits

6099ab666307827a9e05aa40c85e88dabccbf0c0 and
5db96f79632f0788cf115697d0251516d2f86a2e

introduced two issues:

(1) Incorrect arguments to ServrAPI.new
(2) A change in ssl verification behavior

This fixes (1) and makes (2) configurable.

Signed-off-by: Steven Danna <steve@chef.io>