### PR TITLE
Chef16 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ deploy:
   provider: rubygems
 language: ruby
 rvm:
-  - 2.2.6
+  - 2.6.5
 script:
   - bundle exec rspec

--- a/lib/omniauth-chef/version.rb
+++ b/lib/omniauth-chef/version.rb
@@ -16,6 +16,6 @@
 
 module OmniAuth
   module Chef
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end

--- a/omniauth-chef.gemspec
+++ b/omniauth-chef.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake',        '~> 10'
   spec.add_development_dependency 'rspec',       '~>  2'
 
-  spec.add_runtime_dependency 'chef',     '~> 12'
+  spec.add_runtime_dependency 'chef',     '~> 16'
   spec.add_runtime_dependency 'omniauth', '~>  1.2'
 end


### PR DESCRIPTION
oc-id needs its chef gem updated as part of that this is also pulled in and uses chef12. 

## Description
Pulls in the latest chef gem so that oc-id can also use the latest. 

## Related Issue
https://github.com/chef/chef/issues/8376

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
